### PR TITLE
Change unknown course text

### DIFF
--- a/forum/services/schedule_services.py
+++ b/forum/services/schedule_services.py
@@ -222,7 +222,7 @@ def process_schedule_for_user(user, raw_schedule):
                 block_attr = f"block_{normalized.upper()}"
                 course = getattr(profile, block_attr, None)
                 processed_schedule.append({
-                    "block": course.name if course else "Add your courses in profile to unlock this!",
+                    "block": course.name if course else None,
                     "time": time
                 })
             else:

--- a/forum/templates/forum/for_you.html
+++ b/forum/templates/forum/for_you.html
@@ -40,7 +40,7 @@
                                 {% else %}
                                     <li class="list-group-item">
                                         <div class="d-flex justify-content-between align-items-center mb-1">
-                                            <p style = "margin-bottom: 0px;">{{ item.block }}</p>
+                                            <p style = "margin-bottom: 0px;">{{ "<b>Unknown Course</b>" if item.block is None else item.block}}</p>
                                             {% if item.time %}
                                                 <p style = "margin-bottom: 0px;">{{ item.time }} </p>
                                             {% endif %}


### PR DESCRIPTION
The current text on the home page for an un-entered course ("Add your courses in profile to unlock this!") is too long on certain devices (i.e. mine), and messes with the page formatting. While changing it to something shorter ("Unknown course"), I also bolded the text for unknown courses specifically, and changed the way an unknown course is internally represented (to allow for that custom formatting, also cleaner).

This has about a 30-40% chance of breaking the mobile code, but I cannot for the life of me find how the values from process_schedule_for_user get to the app, so perhaps they're directly obtained? Who knows, merge at your own risk.
